### PR TITLE
Build images for multiple architectures (#7)

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,12 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
 name: Publish Docker image
 
 on:
@@ -43,12 +34,23 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: telicent/elasticsearch
-      
-      - name: Build and push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
         with:
+          platforms: all
+
+      - name: Setup Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Build, tag, and push image to DockerHub
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           context: .
           file: ./Dockerfile
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -36,16 +36,16 @@ jobs:
           images: telicent/elasticsearch
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
         with:
           platforms: all
 
       - name: Setup Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
 
       - name: Build, tag, and push image to DockerHub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR updates the `dockerhub.yml` Actions Workflow to use `docker buildx` to build the image for multiple architectures.  This should make it easier for developers to pull down and use the image on different platforms

In testing this reduced the startup time for the container from around ~1m15s using the amd64 image under emulation vs 10s using the native arm64 image for my OS.

See the `7.17.5.2` tag which now supports both amd64 and arm64 architectures - https://hub.docker.com/r/telicent/elasticsearch/tags

This resolves #7 